### PR TITLE
Adding support for GraphQL comments

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -23,15 +23,15 @@ function getSortedChildNodes(node, text, resultArray) {
 
   if (resultArray) {
     if (
-      (node &&
-        (node.type &&
-          node.type !== "CommentBlock" &&
-          node.type !== "CommentLine" &&
-          node.type !== "Line" &&
-          node.type !== "Block" &&
-          node.type !== "EmptyStatement" &&
-          node.type !== "TemplateElement")) ||
-      (node.kind && node.kind !== "Comment")
+      node &&
+      ((node.type &&
+        node.type !== "CommentBlock" &&
+        node.type !== "CommentLine" &&
+        node.type !== "Line" &&
+        node.type !== "Block" &&
+        node.type !== "EmptyStatement" &&
+        node.type !== "TemplateElement") ||
+        (node.kind && node.kind !== "Comment"))
     ) {
       // This reverse insertion sort almost always takes constant
       // time because we almost always (maybe always?) append the

--- a/src/comments.js
+++ b/src/comments.js
@@ -223,14 +223,25 @@ function attach(comments, ast, text) {
         addDanglingComment(ast, comment);
       }
     } else if (util.hasNewline(text, locEnd(comment))) {
-      if (precedingNode.kind) {
+      if (
+        (precedingNode &&
+          precedingNode.kind &&
+          (precedingNode.kind === "Field" ||
+            precedingNode.kind === "VariableDefinition")) ||
+        (followingNode &&
+          followingNode.kind &&
+          (followingNode.kind === "Field" ||
+            followingNode.kind === "OperationDefinition"))
+      ) {
         if (
           precedingNode.kind === "Field" ||
           precedingNode.kind === "VariableDefinition"
         ) {
           addLeadingComment(precedingNode, comment);
+          // return;
         } else if (followingNode) {
           addLeadingComment(followingNode, comment);
+          // return;
         }
       } else if (
         handleLastFunctionArgComments(

--- a/src/comments.js
+++ b/src/comments.js
@@ -23,16 +23,15 @@ function getSortedChildNodes(node, text, resultArray) {
 
   if (resultArray) {
     if (
-      node &&
-      (
-      node.type &&
-      node.type !== "CommentBlock" &&
-      node.type !== "CommentLine" &&
-      node.type !== "Line" &&
-      node.type !== "Block" &&
-      node.type !== "EmptyStatement" &&
-      node.type !== "TemplateElement"
-      ) || (node.kind && node.kind !== "Comment")
+      (node &&
+        (node.type &&
+          node.type !== "CommentBlock" &&
+          node.type !== "CommentLine" &&
+          node.type !== "Line" &&
+          node.type !== "Block" &&
+          node.type !== "EmptyStatement" &&
+          node.type !== "TemplateElement")) ||
+      (node.kind && node.kind !== "Comment")
     ) {
       // This reverse insertion sort almost always takes constant
       // time because we almost always (maybe always?) append the
@@ -70,7 +69,12 @@ function getSortedChildNodes(node, text, resultArray) {
     });
   }
 
-  for (let i = 0, nameCount = names.length; i < nameCount; ++i) {
+  for (
+    let i = 0,
+      nameCount = names.length;
+    i < nameCount;
+    ++i
+  ) {
     getSortedChildNodes(node[names[i]], text, resultArray);
   }
 
@@ -81,8 +85,9 @@ function getSortedChildNodes(node, text, resultArray) {
 // .precedingNode, .enclosingNode, and/or .followingNode properties, at
 // least one of which is guaranteed to be defined.
 function decorateComment(node, comment, text) {
-  const childNodes = getSortedChildNodes(node, text)
-  .filter(node => node.kind !== '<SOF>' && node.kind !== '<EOF>')
+  const childNodes = getSortedChildNodes(node, text).filter(
+    node => node.kind !== "<SOF>" && node.kind !== "<EOF>"
+  );
   let precedingNode, followingNode;
   // Time to dust off the old binary search robes and wizard hat.
   let left = 0,

--- a/src/comments.js
+++ b/src/comments.js
@@ -24,6 +24,7 @@ function getSortedChildNodes(node, text, resultArray) {
   if (resultArray) {
     if (
       node &&
+      (
       node.type &&
       node.type !== "CommentBlock" &&
       node.type !== "CommentLine" &&
@@ -31,6 +32,7 @@ function getSortedChildNodes(node, text, resultArray) {
       node.type !== "Block" &&
       node.type !== "EmptyStatement" &&
       node.type !== "TemplateElement"
+      ) || (node.kind && node.kind !== "Comment")
     ) {
       // This reverse insertion sort almost always takes constant
       // time because we almost always (maybe always?) append the
@@ -79,7 +81,8 @@ function getSortedChildNodes(node, text, resultArray) {
 // .precedingNode, .enclosingNode, and/or .followingNode properties, at
 // least one of which is guaranteed to be defined.
 function decorateComment(node, comment, text) {
-  const childNodes = getSortedChildNodes(node, text);
+  const childNodes = getSortedChildNodes(node, text)
+  .filter(node => node.kind !== '<SOF>' && node.kind !== '<EOF>')
   let precedingNode, followingNode;
   // Time to dust off the old binary search robes and wizard hat.
   let left = 0,
@@ -827,7 +830,9 @@ function printComment(commentPath, options) {
   const comment = commentPath.getValue();
   comment.printed = true;
 
-  switch (comment.type) {
+  switch (comment.type || comment.kind) {
+    case "Comment":
+      return "#" + comment.value;
     case "CommentBlock":
     case "Block":
       return "/*" + comment.value + "*/";

--- a/src/comments.js
+++ b/src/comments.js
@@ -69,12 +69,7 @@ function getSortedChildNodes(node, text, resultArray) {
     });
   }
 
-  for (
-    let i = 0,
-      nameCount = names.length;
-    i < nameCount;
-    ++i
-  ) {
+  for (let i = 0, nameCount = names.length; i < nameCount; ++i) {
     getSortedChildNodes(node[names[i]], text, resultArray);
   }
 
@@ -228,7 +223,16 @@ function attach(comments, ast, text) {
         addDanglingComment(ast, comment);
       }
     } else if (util.hasNewline(text, locEnd(comment))) {
-      if (
+      if (precedingNode.kind) {
+        if (
+          precedingNode.kind === "Field" ||
+          precedingNode.kind === "VariableDefinition"
+        ) {
+          addLeadingComment(precedingNode, comment);
+        } else if (followingNode) {
+          addLeadingComment(followingNode, comment);
+        }
+      } else if (
         handleLastFunctionArgComments(
           text,
           precedingNode,

--- a/src/comments.js
+++ b/src/comments.js
@@ -85,9 +85,7 @@ function getSortedChildNodes(node, text, resultArray) {
 // .precedingNode, .enclosingNode, and/or .followingNode properties, at
 // least one of which is guaranteed to be defined.
 function decorateComment(node, comment, text) {
-  const childNodes = getSortedChildNodes(node, text).filter(
-    node => node.kind !== "<SOF>" && node.kind !== "<EOF>"
-  );
+  const childNodes = getSortedChildNodes(node, text);
   let precedingNode, followingNode;
   // Time to dust off the old binary search robes and wizard hat.
   let left = 0,
@@ -973,6 +971,9 @@ function printComments(path, print, options, needsSemi) {
   const value = path.getValue();
   const printed = print(path);
   const comments = value && value.comments;
+  if (value) {
+    console.log('value', value, value.comments)
+  }
 
   if (!comments || comments.length === 0) {
     return prependCursorPlaceholder(path, options, printed);

--- a/src/comments.js
+++ b/src/comments.js
@@ -971,9 +971,6 @@ function printComments(path, print, options, needsSemi) {
   const value = path.getValue();
   const printed = print(path);
   const comments = value && value.comments;
-  if (value) {
-    console.log('value', value, value.comments)
-  }
 
   if (!comments || comments.length === 0) {
     return prependCursorPlaceholder(path, options, printed);

--- a/src/comments.js
+++ b/src/comments.js
@@ -224,26 +224,6 @@ function attach(comments, ast, text) {
       }
     } else if (util.hasNewline(text, locEnd(comment))) {
       if (
-        (precedingNode &&
-          precedingNode.kind &&
-          (precedingNode.kind === "Field" ||
-            precedingNode.kind === "VariableDefinition")) ||
-        (followingNode &&
-          followingNode.kind &&
-          (followingNode.kind === "Field" ||
-            followingNode.kind === "OperationDefinition"))
-      ) {
-        if (
-          precedingNode.kind === "Field" ||
-          precedingNode.kind === "VariableDefinition"
-        ) {
-          addLeadingComment(precedingNode, comment);
-          // return;
-        } else if (followingNode) {
-          addLeadingComment(followingNode, comment);
-          // return;
-        }
-      } else if (
         handleLastFunctionArgComments(
           text,
           precedingNode,
@@ -274,7 +254,13 @@ function attach(comments, ast, text) {
         handleOnlyComments(enclosingNode, ast, comment, isLastComment) ||
         handleClassMethodComments(enclosingNode, comment) ||
         handleTypeAliasComments(enclosingNode, followingNode, comment) ||
-        handleVariableDeclaratorComments(enclosingNode, followingNode, comment)
+        handleVariableDeclaratorComments(
+          enclosingNode,
+          followingNode,
+          comment
+        ) ||
+        handleTrailingGraphQLComments(precedingNode, comment) ||
+        handleLeadingGraphQLComments(followingNode, comment)
       ) {
         // We're good
       } else if (precedingNode) {
@@ -837,6 +823,32 @@ function handleVariableDeclaratorComments(
     followingNode &&
     (followingNode.type === "ObjectExpression" ||
       followingNode.type === "ArrayExpression")
+  ) {
+    addLeadingComment(followingNode, comment);
+    return true;
+  }
+  return false;
+}
+
+function handleTrailingGraphQLComments(precedingNode, comment) {
+  if (
+    precedingNode &&
+    precedingNode.kind &&
+    (precedingNode.kind === "Field" ||
+      precedingNode.kind === "VariableDefinition")
+  ) {
+    addLeadingComment(precedingNode, comment);
+    return true;
+  }
+  return false;
+}
+
+function handleLeadingGraphQLComments(followingNode, comment) {
+  if (
+    followingNode &&
+    followingNode.kind &&
+    (followingNode.kind === "Field" ||
+      followingNode.kind === "OperationDefinition")
   ) {
     addLeadingComment(followingNode, comment);
     return true;

--- a/src/options.js
+++ b/src/options.js
@@ -37,6 +37,8 @@ function normalize(options) {
     normalized.parser = "typescript";
   } else if (/\.json$/.test(filepath)) {
     normalized.parser = "json";
+  } else if (/\.graphql$/.test(filepath)) {
+    normalized.parser = "graphql";
   }
 
   if (typeof normalized.trailingComma === "boolean") {

--- a/src/parser-graphql.js
+++ b/src/parser-graphql.js
@@ -2,11 +2,26 @@
 
 const createError = require("./parser-create-error");
 
+function parseComments(ast) {
+  const comments = [];
+  const startToken = ast.loc.startToken;
+  let next = startToken.next;
+  while (next.kind !== "<EOF>") {
+    if (next.kind === "Comment") {
+      comments.push(next);
+    }
+    next = next.next;
+  }
+
+  return comments;
+}
+
 function parse(text) {
   // Inline the require to avoid loading all the JS if we don't use it
   const parser = require("graphql/language");
   try {
     const ast = parser.parse(text);
+    ast.comments = parseComments(ast);
     return ast;
   } catch (error) {
     const GraphQLError = require("graphql/error").GraphQLError;

--- a/src/printer-graphql.js
+++ b/src/printer-graphql.js
@@ -21,6 +21,9 @@ function genericPrint(path, options, print) {
   }
 
   switch (n.kind) {
+    case "Comment": {
+      return concat(["# ", n.value.trim()]);
+    }
     case "Document": {
       return join(concat([hardline, hardline]), path.map(print, "definitions"));
     }

--- a/src/printer-graphql.js
+++ b/src/printer-graphql.js
@@ -21,9 +21,6 @@ function genericPrint(path, options, print) {
   }
 
   switch (n.kind) {
-    case "Comment": {
-      return concat(["# ", n.value.trim()]);
-    }
     case "Document": {
       return join(concat([hardline, hardline]), path.map(print, "definitions"));
     }

--- a/src/util.js
+++ b/src/util.js
@@ -231,7 +231,7 @@ function locStart(node) {
     return lineColumnToIndex(node.source.start, node.source.input.css) - 1;
   }
   if (node.loc) {
-    return node.loc.start
+    return node.loc.start;
   }
 }
 
@@ -252,9 +252,10 @@ function locEnd(node) {
     return Math.max(loc, locEnd(node.typeAnnotation));
   }
 
-  if (node.loc) {
-    return node.loc.end
+  if (node.loc && !loc) {
+    return node.loc.end;
   }
+
   return loc;
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -230,6 +230,9 @@ function locStart(node) {
   if (node.source) {
     return lineColumnToIndex(node.source.start, node.source.input.css) - 1;
   }
+  if (node.loc) {
+    return node.loc.start
+  }
 }
 
 function locEnd(node) {
@@ -247,6 +250,10 @@ function locEnd(node) {
   }
   if (node.typeAnnotation) {
     return Math.max(loc, locEnd(node.typeAnnotation));
+  }
+
+  if (node.loc) {
+    return node.loc.end
   }
   return loc;
 }

--- a/tests/graphql_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fields.graphql 1`] = `
+query { # Some comment
+  someField # Some comment
+}
+
+query ($id: ID!) { # Some comment
+  someField(id: $id) # Some comment
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+query {
+  someField
+}
+
+query($id: ID!) {
+  someField(id: $id)
+}
+`;

--- a/tests/graphql_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,11 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`argument_comment.graphql 1`] = `
+
+query (
+  $string: String, # Some variable comment
+  $bool: Boolean # Some comment
+ ) {
+   someField
+ }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+query(
+  # Some variable comment
+  $string: String,
+  # Some comment
+  $bool: Boolean
+) {
+  someField
+}
+`;
+
 exports[`fields.graphql 1`] = `
 query { 
-  someField # foo
+  someField # Trailing comment
 }
+
+query { # Another trailing comment
+  someField
+}
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 query {
-  someField # foo
+  # Trailing comment
+  someField
+}
+
+query {
+  # Another trailing comment
+  someField
+}
+`;
+
+exports[`operation_comment.graphql 1`] = `
+# query comment
+query { 
+  someField
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# query comment
+query {
+  someField
 }
 `;

--- a/tests/graphql_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,19 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`fields.graphql 1`] = `
-query { # Some comment
-  someField # Some comment
-}
-
-query ($id: ID!) { # Some comment
-  someField(id: $id) # Some comment
+query { 
+  someField # foo
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 query {
-  someField
-}
-
-query($id: ID!) {
-  someField(id: $id)
+  someField # foo
 }
 `;

--- a/tests/graphql_comments/argument_comment.graphql
+++ b/tests/graphql_comments/argument_comment.graphql
@@ -1,0 +1,7 @@
+
+query (
+  $string: String, # Some variable comment
+  $bool: Boolean # Some comment
+ ) {
+   someField
+ }

--- a/tests/graphql_comments/fields.graphql
+++ b/tests/graphql_comments/fields.graphql
@@ -1,3 +1,3 @@
-query { # foo
-  someField 
+query { 
+  someField # foo
 }

--- a/tests/graphql_comments/fields.graphql
+++ b/tests/graphql_comments/fields.graphql
@@ -1,0 +1,3 @@
+query { # foo
+  someField 
+}

--- a/tests/graphql_comments/fields.graphql
+++ b/tests/graphql_comments/fields.graphql
@@ -1,3 +1,9 @@
 query { 
-  someField # foo
+  someField # Trailing comment
 }
+
+query { # Another trailing comment
+  someField
+}
+
+

--- a/tests/graphql_comments/jsfmt.spec.js
+++ b/tests/graphql_comments/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "graphql" });

--- a/tests/graphql_comments/operation_comment.graphql
+++ b/tests/graphql_comments/operation_comment.graphql
@@ -1,0 +1,4 @@
+# query comment
+query { 
+  someField
+}

--- a/tests/graphql_union_types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_union_types/__snapshots__/jsfmt.spec.js.snap
@@ -52,5 +52,7 @@ union longUnion =
   | K
   | L
 
+# comment
+# comment2
 union union = B | C | D
 `;


### PR DESCRIPTION
here's my WIP branch — the comments are being extracted from the GraphQL AST and are being attached to the preceding node. we have to call `comments.printComments` somewhere in `printer-graphql` and that's the last step to getting them to print properly.

the tests will continue to fail until that comment gets printed, im just having trouble wrapping my head around how to get the correct node iterated over in `printer-graphql` to be printed

/cc @vjeux @stubailo  